### PR TITLE
Added text node to script or style tags even if empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -1399,10 +1399,8 @@ function text(state) {
       const start = match.index;
       const end = re.lastIndex;
       state.scryle = null; // reset the script/style flag now
-      // write the tag content, if any
-      if (start > pos) {
-        parseSpecialTagsContent(state, name, match);
-      }
+      // write the tag content
+      parseSpecialTagsContent(state, name, match);
       // now the closing tag, either </script> or </style>
       pushTag(state, `/${name}`, start, end);
       break
@@ -1598,19 +1596,19 @@ const TREE_BUILDER_STRUCT = Object.seal({
   },
   pushText(store, node) {
     const text = node.text;
-    const empty = !/\S/.test(text);
     const scryle = store.scryle;
     if (!scryle) {
       // store.last always have a nodes property
       const parent = store.last;
-
+      
       const pack = this.compact && !parent[IS_RAW];
+      const empty = !/\S/.test(text);
       if (pack && empty) {
         return
       }
       this.split(node, text, node.start, pack);
       parent.nodes.push(node);
-    } else if (!empty) {
+    } else {
       scryle.text = node;
     }
   },

--- a/index.js
+++ b/index.js
@@ -1400,7 +1400,16 @@ function text(state) {
       const end = re.lastIndex;
       state.scryle = null; // reset the script/style flag now
       // write the tag content
-      parseSpecialTagsContent(state, name, match);
+      if (start > pos) {
+        parseSpecialTagsContent(state, name, match);
+      } else if (name !== TEXTAREA_TAG) {
+        state.last.text = {
+          type: TEXT,
+          text: '',
+          start: pos,
+          end: pos
+        };
+      }
       // now the closing tag, either </script> or </style>
       pushTag(state, `/${name}`, start, end);
       break

--- a/src/parsers/text.js
+++ b/src/parsers/text.js
@@ -32,10 +32,8 @@ export default function text(state) {
       const start = match.index
       const end = re.lastIndex
       state.scryle = null // reset the script/style flag now
-      // write the tag content, if any
-      if (start > pos) {
-        parseSpecialTagsContent(state, name, match)
-      }
+      // write the tag content
+      parseSpecialTagsContent(state, name, match)
       // now the closing tag, either </script> or </style>
       pushTag(state, `/${name}`, start, end)
       break

--- a/src/parsers/text.js
+++ b/src/parsers/text.js
@@ -33,7 +33,16 @@ export default function text(state) {
       const end = re.lastIndex
       state.scryle = null // reset the script/style flag now
       // write the tag content
-      parseSpecialTagsContent(state, name, match)
+      if (start > pos) {
+        parseSpecialTagsContent(state, name, match)
+      } else if (name !== TEXTAREA_TAG) {
+        state.last.text = {
+          type: TEXT,
+          text: '',
+          start: pos,
+          end: pos
+        }
+      }
       // now the closing tag, either </script> or </style>
       pushTag(state, `/${name}`, start, end)
       break

--- a/src/tree-builder.js
+++ b/src/tree-builder.js
@@ -175,19 +175,19 @@ const TREE_BUILDER_STRUCT = Object.seal({
   },
   pushText(store, node) {
     const text = node.text
-    const empty = !/\S/.test(text)
     const scryle = store.scryle
     if (!scryle) {
       // store.last always have a nodes property
       const parent = store.last
-
+      
       const pack = this.compact && !parent[IS_RAW]
+      const empty = !/\S/.test(text)
       if (pack && empty) {
         return
       }
       this.split(node, text, node.start, pack)
       parent.nodes.push(node)
-    } else if (!empty) {
+    } else {
       scryle.text = node
     }
   },

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,3 @@
+import parser from "./index.js";
+debugger
+console.log(parser().parse("<component><script></script></component>").output);

--- a/test.mjs
+++ b/test.mjs
@@ -1,3 +1,0 @@
-import parser from "./index.js";
-debugger
-console.log(parser().parse("<component><script></script></component>").output);

--- a/test/tparser.js
+++ b/test/tparser.js
@@ -769,6 +769,62 @@ export default {
     ]
   },
 
+  'style tag with zero-length content has empty text node': {
+    data: "<component><style></style></component>",
+    expected: [
+      {
+        type: 1,
+        name: 'component',
+        start: 0,
+        end: 11,
+        isCustom: true,
+      },
+      {
+        type: 1,
+        name: 'style',
+        start: 11,
+        end: 18,
+        text: { type: 3, text: '', start: 18, end: 18 },
+      },
+      { type: 1, name: '/style', start: 18, end: 26 },
+      {
+        type: 1,
+        name: '/component',
+        start: 26,
+        end: 38,
+        isCustom: true,
+      },
+    ]
+  },
+
+  'style tag with content containing only whiteline characters has text node': {
+    data: "<component><style>  </style></component>",
+    expected: [
+      {
+        type: 1,
+        name: 'component',
+        start: 0,
+        end: 11,
+        isCustom: true,
+      },
+      {
+        type: 1,
+        name: 'style',
+        start: 11,
+        end: 18,
+      },
+      { type: 3, text: '  ', start: 18, end: 20 },
+      { type: 1, name: '/style', start: 20, end: 28 },
+      {
+        type: 1,
+        name: '/component',
+        start: 28,
+        end: 40,
+        isCustom: true,
+      },
+    ]
+  },
+
   'whitespace after the tag name is ignored #1': {
     data: '<div\t\n\n  \n\t/>',
     expected: [{ type: _T.TAG, name: 'div', end: 13, isSelfClosing: true }],

--- a/test/tparser.js
+++ b/test/tparser.js
@@ -698,6 +698,7 @@ export default {
             valueStart: 18,
           },
         ],
+        text: { type: 3, text: '', start: 37, end: 37 },
       },
       { type: 1, name: '/script', start: 37, end: 46 },
       {
@@ -705,10 +706,67 @@ export default {
         name: 'script',
         start: 46,
         end: 54,
+        text: { type: 3, text: '', start: 54, end: 54 },
       },
       { type: 1, name: '/script', start: 54, end: 63 },
       { type: 1, name: '/div', start: 63, end: 69 },
     ],
+  },
+
+  'script tag with zero-length content has empty text node': {
+    data: "<component><script></script></component>",
+    expected: [
+      {
+        type: 1,
+        name: 'component',
+        start: 0,
+        end: 11,
+        isCustom: true,
+      },
+      {
+        type: 1,
+        name: 'script',
+        start: 11,
+        end: 19,
+        text: { type: 3, text: '', start: 19, end: 19 },
+      },
+      { type: 1, name: '/script', start: 19, end: 28 },
+      {
+        type: 1,
+        name: '/component',
+        start: 28,
+        end: 40,
+        isCustom: true,
+      },
+    ]
+  },
+
+  'script tag with content containing only whiteline characters has text node': {
+    data: "<component><script>  </script></component>",
+    expected: [
+      {
+        type: 1,
+        name: 'component',
+        start: 0,
+        end: 11,
+        isCustom: true,
+      },
+      {
+        type: 1,
+        name: 'script',
+        start: 11,
+        end: 19,
+      },
+      { type: 3, text: '  ', start: 19, end: 21 },
+      { type: 1, name: '/script', start: 21, end: 30 },
+      {
+        type: 1,
+        name: '/component',
+        start: 30,
+        end: 42,
+        isCustom: true,
+      },
+    ]
   },
 
   'whitespace after the tag name is ignored #1': {


### PR DESCRIPTION
#16 

It was quite simple, actually...  
There was a check for text emptiness, so it was simple as removing the check.

I don't think this could be a breaking change, but I had problem running the tests (probably because I'm on Windows?) and I couldn't check if the change broke something else and also I couldn't add the test for the change itself.